### PR TITLE
Refs #3 Added tool to update version number in project tree

### DIFF
--- a/bin/tsh
+++ b/bin/tsh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ###########################################################################
 #
-# Copyright (c) 2001-2014 PDMFC, All Rights Reserved.
+# Copyright (c) 2001-2016 PDMFC, All Rights Reserved.
 #
 #
 # Executes a Tea script read from a file or from stdin. Run with
@@ -54,7 +54,7 @@ function displayHeader() {
 
     cat <<EOF
 Tea ${TEA_VERSION}
-Copyright (c) 2001-2014 PDMFC, All Rights Reserved.
+Copyright (c) 2001-2016 PDMFC, All Rights Reserved.
 
 EOF
 }

--- a/conf/tea-core.conf
+++ b/conf/tea-core.conf
@@ -1,6 +1,6 @@
 #########################################################################
 #
-# Copyright (c) 2008-2013 PDMFC, All Rights Reserved.
+# Copyright (c) 2008-2016 PDMFC, All Rights Reserved.
 #
 #
 # Tea core configuration parameters.
@@ -12,13 +12,34 @@
 #########################################################################
 
 
-
+#
+# Current version of the software.
+#
+# IMPORTANT: Every time you change this version number, you have to
+# run devtools/bin/build-sync-version to propagate the change to other
+# source files.
+#
+TEA_MAIN_VERSION=4.0.0-beta09
 
 
 #
-# The version number for this release.
+# The build number for a release.
 #
-TEA_VERSION=4.0.0-beta09-SNAPSHOT
+# DO NOT CHANGE THIS. It is just a placeholder for the tools involved
+# in creating a release bundle. Read the comments above.
+#
+TEA_BUILD_NUMBER=SNAPSHOT
+
+#
+# Full version number for a release.
+#
+# DO NOT CHANGE THIS. Read the comments above.
+#
+if [ "${TEA_BUILD_NUMBER}" == "" ] ; then
+    TEA_VERSION=${TEA_MAIN_VERSION}
+else
+    TEA_VERSION=${TEA_MAIN_VERSION}-${TEA_BUILD_NUMBER}
+fi
 
 
 

--- a/devtools/bin/build-sync-version
+++ b/devtools/bin/build-sync-version
@@ -1,0 +1,300 @@
+#!/bin/bash
+###########################################################################
+#
+# Copyright (c) 2016 PDMFC, All Rights Reserved.
+#
+#
+# Updates the project version in all pom.xml files to match the
+# version defined in "conf/tea-core.conf".
+#
+###########################################################################
+
+_scriptName=$0
+_scriptDir=$(dirname $0)
+_teaHome=$(cd $_scriptDir/../..; pwd)
+
+source ${_teaHome}/lib/bash/tea-utils.sh
+source ${_teaHome}/conf/tea-core.conf
+
+
+
+
+
+PRODUCT_NAME="Tea"
+TOOL_NAME="Version updater"
+COPYRIGHT_HEADER="Copyright (c) 2016PDMFC, All Rights Reserved."
+PRODUCT_HEADER="${PRODUCT_NAME} ${TEA_VERSION} - ${TOOL_NAME}"
+
+DEFAULT_NEW_BUILD_NUMBER=SNAPSHOT
+
+_newBuildNumber=${DEFAULT_NEW_BUILD_NUMBER}
+_newVersion=
+_isQuiet=false
+_masterConfFile=${_teaHome}/conf/tea-core.conf
+_xsltprocTool=xsltproc
+
+
+
+
+
+#######################################################################
+#
+# The main script.
+#
+#######################################################################
+
+function main () {
+
+    processCliArgs "$@"
+
+    teaCheckForTools \
+        "${_xsltprocTool}"
+    
+    updateVersion
+}
+
+
+
+
+
+###########################################################################
+#
+# Processes the command line options.
+#
+###########################################################################
+
+function processCliArgs () {
+
+    for option in "$@" ; do
+	    case $option in
+	        --quiet )
+		        _isQuiet=true
+		        ;;
+            --build-number=* )
+                _newBuildNumber=$(expr "$option" : '--build-number=\(.*\)')
+                ;;
+	        --help )
+		        displayHelp
+		        exit 0
+		        ;;
+	        --*=* )
+		        option=$(expr $option : '\(--.*\)=.*')
+		        teaError "$option : unknown option. Use --help for details."
+		        ;;
+	        * )
+		        teaError "$option : unknown option. Use --help for details."
+		        ;;
+	    esac
+    done
+
+    if [ -z "$_newBuildNumber" ] ; then
+        teaError "Missing mandatory --build-number option. Use --help for details."
+    fi
+}
+
+
+
+
+
+###########################################################################
+#
+# Displays an help messages describing the configuration options.
+#
+###########################################################################
+
+function displayHelp () {
+
+    cat <<EOF
+
+${PRODUCT_HEADER}
+${COPYRIGHT_HEADER}
+
+Updates the version number in source files.
+
+Available options:
+
+--build-number=BUILD_NUMBER
+    Version number sufix. The product version is obtained by
+    concatenating the main version with the provided build number. If
+    not specified it will default to ${DEFAULT_NEW_BUILD_NUMBER}.
+
+--quiet
+	Do not show any logging messages.
+
+--help
+    Prints this help text.
+
+EOF
+}
+
+
+
+
+
+#######################################################################
+#
+# 
+#
+#######################################################################
+
+function updateVersion () {
+
+    myLog "${PRODUCT_HEADER}"
+    myLog "    Build number : ${_newBuildNumber}"
+
+    updateBuildNumberInConfigFile
+
+    local newVersion=$(source ${_masterConfFile} ; echo ${TEA_VERSION})
+    myLog "Syncing version to ${newVersion}"
+
+    updateVersionInPomFiles
+
+    myLog "Done updating build number to ${_newBuildNumber}"
+}
+
+
+
+
+
+#######################################################################
+#
+# 
+#
+#######################################################################
+
+function updateBuildNumberInConfigFile () {
+
+    local confFile=${_masterConfFile}
+
+    local tmpConfFile=${confFile}.new
+
+    sed "s/^TEA_BUILD_NUMBER=.*/TEA_BUILD_NUMBER=${_newBuildNumber}/" \
+        < ${confFile} \
+        > ${tmpConfFile}
+
+    mv ${tmpConfFile} ${confFile}
+}
+
+
+
+
+
+#######################################################################
+#
+# 
+#
+#######################################################################
+
+function updateVersionInPomFiles () {
+
+    local newVersion=$(source ${_masterConfFile} ; echo ${TEA_VERSION})
+
+    myLog "Updating POM files..."
+
+    local pomBase=${_teaHome}/modules
+    local pomFileList="
+        ${pomBase}/pom.xml
+        ${pomBase}/*/pom.xml
+"
+
+    for pomFile in ${pomFileList} ; do
+        myLog "    $(getRelativePath ${pomFile} ${pomBase})"
+        updateVersionInOnePomFile ${newVersion} ${pomFile}
+    done
+}
+
+
+
+
+
+###########################################################################
+#
+# 
+#
+###########################################################################
+
+function updateVersionInOnePomFile () {
+
+    local newVersion=$1
+    local pomFile=$2
+
+    local newPomVersion=${newVersion}
+    local newParentVersion=${newVersion}
+    local newPomFile=${pomFile}.new
+    local xsltFile=${_scriptDir}/../lib/xslt/build-sync-version/update-pom-version.xsl
+
+    ${_xsltprocTool} \
+        --stringparam NEW_POM_VERSION "${newPomVersion}" \
+        --stringparam NEW_PARENT_VERSION "${newParentVersion}" \
+        --output ${newPomFile} \
+        ${xsltFile} \
+        ${pomFile}
+
+    local xsltprocStatus=$?
+
+    if [ ${xsltprocStatus} -eq 0 ] ; then
+        mv ${newPomFile} ${pomFile}
+    else
+        rm -f ${newPomFile}
+    fi
+}
+
+
+
+
+
+###########################################################################
+#
+# 
+#
+###########################################################################
+
+function myLog () {
+
+    if [ ${_isQuiet} != true ] ; then
+        teaLog "$@"
+    else
+        : # Show no logging.
+    fi
+}
+
+
+
+
+
+#######################################################################
+#
+# 
+#
+#######################################################################
+
+function getRelativePath () {
+
+    local path=$1
+    local basePath=$2
+
+    python -c "import os.path; print os.path.relpath('${path}', '${basePath}')"
+}
+
+
+
+
+
+#######################################################################
+#
+# 
+#
+#######################################################################
+
+main "$@"
+
+
+
+
+
+#######################################################################
+#
+# 
+#
+#######################################################################
+

--- a/devtools/lib/xslt/build-sync-version/update-pom-version.xsl
+++ b/devtools/lib/xslt/build-sync-version/update-pom-version.xsl
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2016 PDMFC, All Rights Reserved.
+
+XSLT for replacing the artifact version and parent version in a POM file.
+-->
+
+<xsl:stylesheet
+    version="1.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:t="http://maven.apache.org/POM/4.0.0">
+
+  <!-- These parameters must be set by the tool running the XSLT
+       transformation. -->
+  <xsl:param name="NEW_POM_VERSION"/>
+  <xsl:param name="NEW_PARENT_VERSION"/>
+
+  <xsl:output method="xml" encoding="UTF-8" />
+  
+  <!-- This is an identity template. It copies everything that does
+       not match another template -->
+  <xsl:template match="@* | node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@* | node()"/>
+    </xsl:copy>
+  </xsl:template>
+  
+  <!-- Replace the project version with the value of the
+       NEW_POM_VERSION parameter. -->
+  <xsl:template match="/t:project/t:version/text()"><xsl:value-of select="$NEW_POM_VERSION"/></xsl:template>
+
+  <!-- Replace the project parent version with the value of the
+       NEW_PARENT_VERSION parameter. -->
+  <xsl:template match="/t:project/t:parent/t:version/text()">
+    <xsl:choose>
+      <xsl:when test="$NEW_PARENT_VERSION!=''"><xsl:value-of select="$NEW_PARENT_VERSION"/></xsl:when>
+      <xsl:otherwise><xsl:value-of select="."/></xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+    
+</xsl:stylesheet>

--- a/lib/bash/tea-utils.sh
+++ b/lib/bash/tea-utils.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ###########################################################################
 #
-# Copyright (c) 2001-2012 PDM&FC, All Rights Reserved.
+# Copyright (c) 2001-2016 PDM&FC, All Rights Reserved.
 #
 #
 # Utility functions. This script is not meant to be executed by
@@ -28,6 +28,25 @@ function teaError () {
 
     echo "***" $1 >&2
     exit 1
+}
+
+
+
+
+
+###########################################################################
+#
+# Displays a message to stdout prefixed with the current time.
+#
+# Arguments:
+#
+# 1. The message to be displayed.
+#
+###########################################################################
+
+function teaLog () {
+
+    echo $(date "+%Y-%m-%d %H:%M:%S") "$@"
 }
 
 
@@ -209,6 +228,30 @@ function teaPathSeparator () {
 	    echo ":"
 	    return
     esac
+}
+
+
+
+
+
+###########################################################################
+#
+# Checks if a set of required tools is available. If any is missing
+# outputs an error message and terminates the process.
+#
+###########################################################################
+
+function teaCheckForTools () {
+
+    local toolList="$@"
+
+    for tool in ${toolList} ; do
+        if type $tool > /dev/null 2>&1 ; then
+            : # All is ok
+        else
+            teaError "Missing \"${tool}\" tool. Please install this tool."
+        fi
+    done
 }
 
 

--- a/modules/engine/pom.xml
+++ b/modules/engine/pom.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
 
 Copyright (c) 2014-2016 PDMFC, All Rights Reserved.
@@ -8,12 +7,7 @@ Copyright (c) 2014-2016 PDMFC, All Rights Reserved.
 Maven POM for the "engine" sub-project.
 
 -->
-
-<project
-   xmlns="http://maven.apache.org/POM/4.0.0"
-   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                        http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <packaging>jar</packaging>
@@ -229,4 +223,3 @@ Maven POM for the "engine" sub-project.
 
 
 </project>
-

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
 
 Copyright (c) 2014-2016 PDMFC, All Rights Reserved.
@@ -9,12 +8,7 @@ Tea project main Maven POM file. See "../README.asciidoc" for details on
 performing a build.
 
 -->
-
-<project
-   xmlns="http://maven.apache.org/POM/4.0.0"
-   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                        http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>
@@ -40,16 +34,16 @@ performing a build.
 
     <!-- The following are used when generating Teadoc
          documentation. -->
-    <tea.teadoc.header><![CDATA[Tea ${tea.version} Reference Documentation<b>&copy; 2014 <a href="http://www.pdmfc.com">PDM&amp;FC</a>]]></tea.teadoc.header>
+    <tea.teadoc.header>Tea ${tea.version} Reference Documentation&lt;b&gt;&amp;copy; 2014 &lt;a href="http://www.pdmfc.com"&gt;PDM&amp;amp;FC&lt;/a&gt;</tea.teadoc.header>
     <tea.teadoc.footer>${tea.teadoc.header}</tea.teadoc.footer>
-    <tea.teadoc.bottom><![CDATA[<font size="-1"><a href="mailto:info@pdmfc.com">Report a bug or request new features</a></font>]]></tea.teadoc.bottom>
+    <tea.teadoc.bottom>&lt;font size="-1"&gt;&lt;a href="mailto:info@pdmfc.com"&gt;Report a bug or request new features&lt;/a&gt;&lt;/font&gt;</tea.teadoc.bottom>
     <tea.teadoc.doctitle>Tea ${tea.version} Reference Documentation</tea.teadoc.doctitle>
     <tea.teadoc.windowtitle>${tea.teadoc.doctitle}</tea.teadoc.windowtitle>
 
     <!-- The following are used when generating Javadoc
          documentation. -->
-    <tea.javadoc.header><![CDATA[<b>Tea Java Runtime API</b><br /><b>Version ${project.version}</b>]]></tea.javadoc.header>
-    <tea.javadoc.bottom><![CDATA[<font size="-1">&copy; 2014 <a href="http://www.pdmfc.com" target="_blank">PDMFC</a>, All Rights Reserved.</font>]]></tea.javadoc.bottom>
+    <tea.javadoc.header>&lt;b&gt;Tea Java Runtime API&lt;/b&gt;&lt;br /&gt;&lt;b&gt;Version ${project.version}&lt;/b&gt;</tea.javadoc.header>
+    <tea.javadoc.bottom>&lt;font size="-1"&gt;&amp;copy; 2014 &lt;a href="http://www.pdmfc.com" target="_blank"&gt;PDMFC&lt;/a&gt;, All Rights Reserved.&lt;/font&gt;</tea.javadoc.bottom>
     <tea.javadoc.doctitle>${project.name} ${project.version}</tea.javadoc.doctitle>
     <tea.javadoc.windowtitle>${tea.javadoc.doctitle}</tea.javadoc.windowtitle>
 
@@ -411,4 +405,3 @@ performing a build.
 
 
 </project>
-

--- a/modules/release/pom.xml
+++ b/modules/release/pom.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
 
 Copyright (c) 2014-2016 PDMFC, All Rights Reserved.
@@ -8,12 +7,7 @@ Copyright (c) 2014-2016 PDMFC, All Rights Reserved.
 Maven POM for the "release" sub-project.
 
 -->
-
-<project
-   xmlns="http://maven.apache.org/POM/4.0.0"
-   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                        http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>
@@ -91,7 +85,7 @@ Maven POM for the "release" sub-project.
                   <executable>${java.home}/bin/java</executable>
                   <arguments>
                     <argument>-classpath</argument>
-                    <classpath />
+                    <classpath/>
                     <argument>com.pdmfc.tea.tools.runner.TeaRunner</argument>
                     <argument>--encoding=${project.build.sourceEncoding}</argument>
                     <argument>--library=${tea.projectRootDir}/apps/teadoc/lib/tea</argument>
@@ -182,4 +176,3 @@ Maven POM for the "release" sub-project.
 
 
 </project>
-

--- a/modules/runner/pom.xml
+++ b/modules/runner/pom.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
 
 Copyright (c) 2014-2016 PDMFC, All Rights Reserved.
@@ -8,12 +7,7 @@ Copyright (c) 2014-2016 PDMFC, All Rights Reserved.
 Maven POM for the "runner" sub-project.
 
 -->
-
-<project
-   xmlns="http://maven.apache.org/POM/4.0.0"
-   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                        http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <packaging>jar</packaging>
@@ -219,7 +213,7 @@ Maven POM for the "runner" sub-project.
                   <arguments>
                     <argument>-Dderby.stream.error.file=${project.build.directory}/derby.log</argument>
                     <argument>-classpath</argument>
-                    <classpath />
+                    <classpath/>
                     <argument>com.pdmfc.tea.tools.runner.TeaRunner</argument>
                     <argument>--script=resource:/lib/tea-${project.version}/tea/tools/tunit/tunit-main.tea</argument>
                     <argument>--</argument>
@@ -268,7 +262,7 @@ Maven POM for the "runner" sub-project.
                   <executable>${java.home}/bin/java</executable>
                   <arguments>
                     <argument>-classpath</argument>
-                    <classpath />
+                    <classpath/>
                     <argument>com.pdmfc.tea.tools.runner.TeaRunner</argument>
                     <argument>--encoding=${project.build.sourceEncoding}</argument>
                     <argument>--library=${tea.projectRootDir}/apps/teadoc/lib/tea</argument>
@@ -355,4 +349,3 @@ Maven POM for the "runner" sub-project.
 
 
 </project>
-

--- a/modules/runtime/pom.xml
+++ b/modules/runtime/pom.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
 
 Copyright (c) 2014-2016 PDMFC, All Rights Reserved.
@@ -8,12 +7,7 @@ Copyright (c) 2014-2016 PDMFC, All Rights Reserved.
 Maven POM for the "runtime" sub-project.
 
 -->
-
-<project
-   xmlns="http://maven.apache.org/POM/4.0.0"
-   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                        http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <packaging>jar</packaging>
@@ -207,4 +201,3 @@ Maven POM for the "runtime" sub-project.
 
 
 </project>
-


### PR DESCRIPTION
Added 'devtools/bin/build-sync-version' for updating the software
version number in all required files. This tool is intended for use
only in the development environment.

This tool has two main purposes:
- Simplify the developers life when th version number changes - Only
  one file will need to be manually modified (conf/tea-core.conf).
- During the generation of a release bundle allow to use a unique
  build number as part of the version.
